### PR TITLE
Remove obsolete call, which lead to the brake at the node build

### DIFF
--- a/src/lib/bls-sdk.js
+++ b/src/lib/bls-sdk.js
@@ -389,7 +389,6 @@ export const wasmBlsSdkHelpers = new (function () {
     }
     const RNG_VALUES_SIZE = globalThis.wasmExports.get_rng_values_size();
     const rngValues = new Uint32Array(RNG_VALUES_SIZE);
-    window.crypto.getRandomValues(rngValues);
     for (let i = 0; i < rngValues.length; i++) {
       globalThis.wasmExports.set_rng_value(i, rngValues[i]);
     }


### PR DESCRIPTION
Hey folks,  I am using your lib on the backend (as part of our project at Denver ETH 2022),
So there we doing some proxy issuing and that's why I need it on the Node js. I mostly using there :

LitJsSdk.encryptString
LitJsSdk.decryptString
LitJsSdk.litNodeClient.saveEncryptionKey
LitJsSdk.litNodeClient.getEncryptionKey

methods from the 'lit-js-sdk/build/index.node.js'
and this redundant line make silent [erroring here](https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/lib/bls-sdk.js#L422)
which lead that encryptedKey [here](https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/utils/litNodeClient.js#L479) is always empty.

P.S. also I was forced to do such hack at my project
```
const Blob = require('cross-blob')
global.Blob = Blob
```
cause of Blob is node deinfed error, so probably would be cool if for the node build will be added something like

```
if (!Blob) {
  globalThis.Blob = require('cross-blob')
}
```

Thnx! P.S. Really like the idea of such generic permissions layer, keep rocking!
