### PR TITLE
Replace web3-provider with ethereum-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@metamask/detect-provider": "^1.2.0",
     "@solana/web3.js": "^1.35.0",
     "@unstoppabledomains/resolution": "^7.1.2",
-    "@walletconnect/web3-provider": "^1.6.6",
+    "@walletconnect/ethereum-provider": "^1.6.6",
     "buffer": "^6.0.3",
     "bufferutil": "^4.0.6",
     "cross-blob": "^3.0.1",

--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,6 @@ yarn build
 yarn buildWeb
 yarn buildNode
 
-yarn publish --new-version $VERSION
+yarn publish --new-version $VERSION --access public
 
 echo "Don't forget to git push to get this running on the netlify cdn"

--- a/src/utils/eth.js
+++ b/src/utils/eth.js
@@ -5,7 +5,7 @@ import { Web3Provider, JsonRpcSigner } from "@ethersproject/providers";
 import { toUtf8Bytes } from "@ethersproject/strings";
 import { hexlify } from "@ethersproject/bytes";
 import Web3Modal from "web3modal";
-import WalletConnectProvider from "@walletconnect/web3-provider";
+import WalletConnectProvider from "@walletconnect/ethereum-provider";
 import Resolution from "@unstoppabledomains/resolution";
 import detectEthereumProvider from "@metamask/detect-provider";
 


### PR DESCRIPTION
- The web3 provider is a pretty terrible package to bundle and ethereum-provider is a good alternative. 

https://github.com/WalletConnect/walletconnect-monorepo/tree/v1.0/packages/providers