### PR TITLE
feat: add typesafe && better naming for const encryptedData from encr…

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -32,3 +32,51 @@ export const log = (...args) => {
   args.unshift("[Lit-JS-SDK]");
   console.log(...args);
 };
+
+/**
+ * 
+ * Get the type of a variable, could be an object instance type. 
+ * eg Uint8Array instance should return 'Uint8Array` as string
+ * or simply a `string` or `int` type
+ * 
+ * @param { * } value 
+ * @returns { String } type
+ */
+ export const getVarType = (value) => {
+
+  // if it's an object
+  if(value instanceof Object){
+      if(value.constructor.name == 'Object'){
+          return 'Object';
+      }
+      return value.constructor.name;
+  }
+
+  // if it's other type, like string and int
+  return typeof value;
+}
+
+/**
+ * 
+ *  Check if the given value is the given type
+ *  If not, throw `invalidParamType` error
+ * 
+ * @param { * } value 
+ * @param { string } type 
+ * @returns { Boolean } true/false
+ */
+export const is = (value, type ) => {
+
+  if( getVarType(value) !== type){
+
+    throwError({
+      message: `Expecting "${type}", but received "${getVarType(value)}" instead. value: ${value instanceof Object ? JSON.stringify(value) : value}`,
+      name: "invalidParamType",
+      errorCode: "invalid_param_type",
+    });
+    return false;
+  }
+
+  return true;
+
+}

--- a/src/utils/lit.js
+++ b/src/utils/lit.js
@@ -4,7 +4,7 @@ import {
   toString as uint8arrayToString,
 } from "uint8arrays";
 import { formatEther, formatUnits } from "@ethersproject/units";
-import { throwError, log } from "../lib/utils";
+import { throwError, log, is } from "../lib/utils";
 
 import {
   importSymmetricKey,
@@ -70,6 +70,10 @@ export async function checkAndSignAuthMessage({ chain, resources }) {
  * @returns {Promise<Object>} A promise containing the encryptedString as a Blob and the symmetricKey used to encrypt it, as a Uint8Array.
  */
 export async function encryptString(str) {
+
+  // -- validate
+  if( ! is(str, 'string')) return;
+
   const encodedString = uint8arrayFromString(str, "utf8");
 
   const symmKey = await generateSymmetricKey();
@@ -85,6 +89,7 @@ export async function encryptString(str) {
   return {
     symmetricKey: exportedSymmKey,
     encryptedString,
+    encryptedData: encryptedString
   };
 }
 
@@ -95,6 +100,11 @@ export async function encryptString(str) {
  * @returns {Promise<string>} A promise containing the decrypted string
  */
 export async function decryptString(encryptedStringBlob, symmKey) {
+
+  // -- validate
+  if( ! is(encryptedStringBlob, 'Blob')) return;
+  if( ! is(symmKey, 'Uint8Array')) return;
+
   // import the decrypted symm key
   const importedSymmKey = await importSymmetricKey(symmKey);
 

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -6,7 +6,7 @@ import naclUtil from "tweetnacl-util";
 
 import { version } from "../version";
 
-import { mostCommonString, throwError, log } from "../lib/utils";
+import { mostCommonString, throwError, log, is } from "../lib/utils";
 import { wasmBlsSdkHelpers } from "../lib/bls-sdk";
 import * as wasmECDSA from "../lib/ecdsa-sdk";
 import { LIT_NETWORKS } from "../lib/constants";
@@ -683,6 +683,15 @@ export default class LitNodeClient {
       });
     }
 
+    // -- validate
+    if( accessControlConditions && ! is(accessControlConditions, 'Array')) return;
+    if( evmContractConditions && ! is(evmContractConditions, 'Array')) return;
+    if( solRpcConditions && ! is(solRpcConditions, 'Array')) return;
+    if( unifiedAccessControlConditions && ! is(unifiedAccessControlConditions, 'Array')) return;
+    if( ! is(toDecrypt, 'string') ) return;
+    if( ! is(chain, 'string') ) return;
+    if( ! is(authSig, 'Object') ) return;
+
     let formattedAccessControlConditions;
     let formattedEVMContractConditions;
     let formattedSolRpcConditions;
@@ -830,6 +839,16 @@ export default class LitNodeClient {
         errorCode: "lit_node_client_not_ready",
       });
     }
+
+    // -- validate
+    if( accessControlConditions && ! is(accessControlConditions, 'Array')) return;
+    if( evmContractConditions && ! is(evmContractConditions, 'Array')) return;
+    if( solRpcConditions && ! is(solRpcConditions, 'Array')) return;
+    if( unifiedAccessControlConditions && ! is(unifiedAccessControlConditions, 'Array')) return;
+    if( ! is(chain, 'string') ) return;
+    if( ! is(authSig, 'Object') ) return;
+    if( ! is(symmetricKey, 'Uint8Array') ) return;
+    if( encryptedSymmetricKey && ! is(encryptedSymmetricKey, 'Uint8Array') ) return;
 
     // to fix spelling mistake
     if (typeof permanant !== "undefined") {


### PR DESCRIPTION
@glitch003 
- Added `getVarType` and `is` functions to utils for checking if the given value is the given type
- Added param type guarding on several functions

an example of wrong `toDecrypt` type:
```
  const _symmetricKey = await litNodeClient.getEncryptionKey({
    accessControlConditions,
    toDecrypt: encryptedSymmetricKey,
    chain,
    authSig
  })
  ``` 
  
 will show this error:
  
![Screenshot 2022-07-15 at 00 39 12](https://user-images.githubusercontent.com/4049673/179118828-740e559a-30cc-403c-be11-f033eabac0b4.png)