### PR TITLE
Draft: Add typescript definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,50 @@
+declare module 'lit-js-sdk' {
+  export interface ILitSdk {
+    LitNodeClient: any;
+    checkAndSignAuthMessage: (config: ICheckAndSignAuthMessageConfig) => Promise<IAuthSignature>;
+  }
+
+  const LitSdk: ILitSdk;
+  export default LitSdk;
+
+  export type TChain = 'ethereum' |
+    'polygon' |
+    'fantom' |
+    'xdai' |
+    'bsc' |
+    'arbitrum' |
+    'avalanche' |
+    'fuji' |
+    'harmony' |
+    'kovan' |
+    'mumbai' |
+    'goerli' |
+    'ropsten' |
+    'rinkeby' |
+    'cronos' |
+    'optimism' |
+    'celo' |
+    'aurora' |
+    'eluvio' |
+    'alfajores' |
+    'xdc' |
+    'evmos' |
+    'evmosTestnet' |
+    'solana' |
+    'solanaDevnet' |
+    'solanaTestnet' |
+    'cosmos' |
+    'kyve';
+  
+  export interface ICheckAndSignAuthMessageConfig {
+    chain: TChain;
+  }
+
+  export interface ILitClient {
+
+  }
+
+  export interface IAuthSignature {
+
+  }
+}


### PR DESCRIPTION
Hey Lit Protocol team 👋 

I would like to add some ambient types to this project to make it typescript compatible. I wanted to open a draft PR pre-emptively to check with you if this would be a desirable thing for the project itself.

I think it is one of the least invasive solutions - since I can imagine doing a JS to TS conversion for a full library would be intensive and not desired by everyone.

Could I ask for your opinions regarding this? An extremely simple part of the code is in the PR - it would just be expanded on to cover all bases (and we can just return `any` as type for anything that may not be typed just yet, as a stop gap).