### PR TITLE
Make address check case-insensitive for signing

### DIFF
--- a/src/utils/eth.js
+++ b/src/utils/eth.js
@@ -406,7 +406,7 @@ export async function signMessage({ body, web3, account }) {
   log("Signature: ", signature);
   log("recovered address: ", address);
 
-  if (address !== account) {
+  if (address !== account.toLowerCase()) {
     const msg = `ruh roh, the user signed with a different address (${address}) then they\'re using with web3 (${account}).  this will lead to confusion.`;
     console.error(msg);
     alert(


### PR DESCRIPTION
The `address` is converted to lower-case a few lines before.

I figured, the `account` could be converted too, because the checksum isn't relevant in that comparison.