### PR TITLE
catch async error when connecting to network

### DIFF
--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -1059,7 +1059,7 @@ export default class LitNodeClient {
         };
       })
         .catch((err) => {
-
+          // catch error so it does not propagate
         });
     }
 

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -1057,7 +1057,10 @@ export default class LitNodeClient {
           networkPubKey: resp.networkPublicKey,
           networkPubKeySet: resp.networkPublicKeySet,
         };
-      });
+      })
+        .catch((err) => {
+
+        });
     }
 
     return new Promise((resolve) => {


### PR DESCRIPTION
When the Lit Protocol is down, there's no way for the user to catch the exception resulting in an unhandledPromiseRejection. This was crashing our application. Not sure if we would want to add some logging, or maybe add a timeout if the client never returns.