### PR TITLE
Test(Manual): Smart Contract (EIP1271) Authsig

### DIFF
--- a/api_docs.md
+++ b/api_docs.md
@@ -839,9 +839,9 @@ Type: [Object][146]
 ### Properties
 
 *   `sig` **[string][149]** The actual hex-encoded signature
-*   `derivedVia` **[string][149]** The method used to derive the signature. Typically "web3.eth.personal.sign"
+*   `derivedVia` **[string][149]** The method used to derive the signature. Typically "web3.eth.personal.sign" or "EIP1271" for smart contract authsig
 *   `signedMessage` **[string][149]** The message that was signed
-*   `address` **[string][149]** The crypto wallet address that signed the message
+*   `address` **[string][149]** The crypto wallet address that signed the message or the smart contract address in case of smart contract authsig
 
 ## Chain Info
 

--- a/build/manual_tests.html
+++ b/build/manual_tests.html
@@ -2542,6 +2542,49 @@ Expiration Time: 2022-12-02T02:14:51.688Z`; // prettier-ignore
         });
       };
 
+      var smartContractAuthSig = async (address) => {
+        const toSign = "Any string message works!";
+        const { web3, account } = await LitJsSdk.connectWeb3();
+        const sig = await LitJsSdk.signMessageAsync(
+          web3.getSigner(),
+          account,
+          toSign
+        );
+        const authSig = {
+          sig,
+          derivedVia: "EIP1271",
+          signedMessage: toSign,
+          address,
+        };
+        const accessControlConditions = [
+          {
+            contractAddress: "",
+            standardContractType: "",
+            chain: "mumbai",
+            method: "eth_getBalance",
+            parameters: [":userAddress", "latest"],
+            returnValueTest: {
+              comparator: ">=",
+              value: "0",
+            },
+          },
+        ];
+        await testProvisoningAndSigning({
+          accessControlConditions,
+          testName: "smartContractAuthSig",
+          authSig,
+          chain: "mumbai"
+        });
+      };
+
+      var smartContractAuthSigValid = async () => {
+        await smartContractAuthSig("0x6FdF5aD7f256D9677eC1d6B7e633Ff1E7FA5Ac14") // Always return true
+      };
+
+      var smartContractAuthSigInvalid = async () => {
+        await smartContractAuthSig("0x056054954b075e9053B5646dc1E2234D51c0E79c") // Always return false
+      };
+
       var logout = async () => {
         const testName = "Logout";
         document.getElementById("status").innerText = `Testing ${testName}...`;
@@ -2795,6 +2838,18 @@ Expiration Time: 2022-12-02T02:14:51.688Z`; // prettier-ignore
     <br />
 
     <button onclick="MonaSig()">MonaSig</button>
+    <br />
+    <br />
+
+    <button onclick="smartContractAuthSigValid()">
+      Smart Contract AuthSig Valid
+    </button>
+    <br />
+    <br />
+
+    <button onclick="smartContractAuthSigInvalid()">
+      Smart Contract AuthSig Invalid
+    </button>
     <br />
     <br />
 

--- a/docs_md
+++ b/docs_md
@@ -207,9 +207,9 @@ Type: [Object][35]
 ### Properties
 
 *   `sig` **[string][36]** The actual hex-encoded signature
-*   `derivedVia` **[string][36]** The method used to derive the signature
+*   `derivedVia` **[string][36]** The method used to derive the signature or "EIP1271" for smart contract authsig
 *   `signedMessage` **[string][36]** The message that was signed
-*   `address` **[string][36]** The crypto wallet address that signed the message
+*   `address` **[string][36]** The crypto wallet address that signed the message or the smart contract address in case of smart contract authsig
 
 ## LITChain
 


### PR DESCRIPTION
# What

Add Manual tests for [Node PR](https://github.com/LIT-Protocol/lit_node_rust/pull/118)

# How

Add 2 tests (on mumbai chain):

1. Smart Contract AuthSig Valid- This calls the isValidSignature function on the [contract](https://mumbai.polygonscan.com/address/0x6FdF5aD7f256D9677eC1d6B7e633Ff1E7FA5Ac14#code#F2#L1) that always returns **true** (0x1626ba7e)
2. Smart Contract AuthSig Invalid- This calls the isValidSignature function on the [contract](https://mumbai.polygonscan.com/address/0x056054954b075e9053B5646dc1E2234D51c0E79c#code#F2#L1) that always returns **false** (0xffffffff)

Internally calls the function: `testProvisoningAndSigning()` passing the constructed `authSig` & `chain` params.