### PR TITLE
Feat: Return node core error to user

### DIFF
--- a/build/manual_tests.html
+++ b/build/manual_tests.html
@@ -1327,7 +1327,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error getting symmetric key - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1409,7 +1409,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error getting symmetric key - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1491,7 +1491,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error getting symmetric key - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1782,7 +1782,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error updating the condition - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1942,7 +1942,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error updating the condition - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -2032,7 +2032,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error updating the condition - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;

--- a/build/manual_tests_error_messages.html
+++ b/build/manual_tests_error_messages.html
@@ -391,7 +391,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error updating the condition - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -661,7 +661,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error getting symmetric key - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (e.error_code === "NodeStorageError") {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;

--- a/build/manual_tests_session_keys.html
+++ b/build/manual_tests_session_keys.html
@@ -129,7 +129,7 @@
             });
           } catch (e) {
             console.log("exception thrown when unlocking", e);
-            if (e.errorCode === "not_authorized") {
+            if (e.error_code === "NodeNotAuthorized") {
               failed = true;
             }
           }

--- a/build/manual_tests_unified.html
+++ b/build/manual_tests_unified.html
@@ -143,7 +143,7 @@
             });
           } catch (e) {
             console.log("exception thrown when unlocking", e);
-            if (e.errorCode === "not_authorized") {
+            if (e.error_code === "NodeNotAuthorized") {
               failed = true;
             }
           }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -91,8 +91,8 @@ export const checkType = ({
     if (throwOnError) {
       throwError({
         description: message,
-        error_kind: "invalidParamType",
-        error_code: "invalid_param_type",
+        error_kind: "Generic",
+        error_code: "InvalidParamType",
       });
     }
     return false;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -15,11 +15,15 @@ export const mostCommonString = (arr) => {
     .pop();
 };
 
-export const throwError = ({ message, name, errorCode }) => {
+export const throwError = ({ error_kind, error_code, status, description, details, message, name, }) => {
   throw new (function () {
-    this.message = message;
-    this.name = name;
-    this.errorCode = errorCode;
+    this.message = message || ""; // !TODO: Remove
+    this.name = name || ""; // !TODO: Remove
+    this.error_kind = error_kind;
+    this.error_code = error_code;
+    this.status = status;
+    this.description = description;
+    this.details = details;
   })();
 };
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -15,15 +15,13 @@ export const mostCommonString = (arr) => {
     .pop();
 };
 
-export const throwError = ({ error_kind, error_code, status, description, details, message, name, }) => {
+export const throwError = ({ error_kind, error_code, status, description, details }) => {
   throw new (function () {
-    this.message = message || ""; // !TODO: Remove
-    this.name = name || ""; // !TODO: Remove
     this.error_kind = error_kind;
     this.error_code = error_code;
-    this.status = status;
+    this.status = status || 400;
     this.description = description;
-    this.details = details;
+    this.details = details || [];
   })();
 };
 
@@ -92,9 +90,9 @@ export const checkType = ({
 
     if (throwOnError) {
       throwError({
-        message,
-        name: "invalidParamType",
-        errorCode: "invalid_param_type",
+        description: message,
+        error_kind: "invalidParamType",
+        error_code: "invalid_param_type",
       });
     }
     return false;

--- a/src/utils/cosmos.js
+++ b/src/utils/cosmos.js
@@ -12,10 +12,10 @@ function getProvider() {
     return keplr;
   } else {
     throwError({
-      message:
+      description:
         "No web3 wallet was found that works with Cosmos.  Install a Cosmos wallet or choose another chain",
-      name: "NoWalletException",
-      errorCode: "no_wallet",
+      error_kind: "NoWalletException",
+      error_code: "no_wallet",
     });
   }
 }

--- a/src/utils/cosmos.js
+++ b/src/utils/cosmos.js
@@ -14,8 +14,8 @@ function getProvider() {
     throwError({
       description:
         "No web3 wallet was found that works with Cosmos.  Install a Cosmos wallet or choose another chain",
-      error_kind: "NoWalletException",
-      error_code: "no_wallet",
+      error_kind: "Validation",
+      error_code: "NodeNoWallet",
     });
   }
 }

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -55,16 +55,16 @@ export function canonicalUnifiedAccessControlConditionFormatter(cond) {
         description: `You passed an invalid access control condition that is missing or has a wrong "conditionType": ${JSON.stringify(
           cond
         )}`,
-        error_kind: "InvalidAccessControlCondition",
-        error_code: "invalid_access_control_condition",
+        error_kind: "Validation",
+        error_code: "NodeIncorrectAccessControlConditions",
       });
     }
   }
 
   throwError({
     description: `You passed an invalid access control condition: ${cond}`,
-    error_kind: "InvalidAccessControlCondition",
-    error_code: "invalid_access_control_condition",
+    error_kind: "Validation",
+    error_code: "NodeIncorrectAccessControlConditions",
   });
 }
 
@@ -117,8 +117,8 @@ export function canonicalCosmosConditionFormatter(cond) {
 
   throwError({
     description: `You passed an invalid access control condition: ${cond}`,
-    error_kind: "InvalidAccessControlCondition",
-    error_code: "invalid_access_control_condition",
+    error_kind: "Validation",
+    error_code: "NodeIncorrectAccessControlConditions",
   });
 }
 
@@ -191,8 +191,8 @@ pub struct SolPdaInterface {
       ) {
         throwError({
           description: `Solana RPC Conditions have changed and there are some new fields you must include in your condition.  Check the docs here: https://developer.litprotocol.com/AccessControlConditions/solRpcConditions`,
-          error_kind: "InvalidAccessControlCondition",
-          error_code: "invalid_access_control_condition",
+          error_kind: "Validation",
+          error_code: "NodeIncorrectAccessControlConditions",
         });
       }
 
@@ -222,8 +222,8 @@ pub struct SolPdaInterface {
 
   throwError({
     description: `You passed an invalid access control condition: ${cond}`,
-    error_kind: "InvalidAccessControlCondition",
-    error_code: "invalid_access_control_condition",
+    error_kind: "Validation",
+    error_code: "NodeIncorrectAccessControlConditions",
   });
 }
 
@@ -331,8 +331,8 @@ export function canonicalEVMContractConditionFormatter(cond) {
 
   throwError({
     description: `You passed an invalid access control condition: ${cond}`,
-    error_kind: "InvalidAccessControlCondition",
-    error_code: "invalid_access_control_condition",
+    error_kind: "Validation",
+    error_code: "NodeIncorrectAccessControlConditions",
   });
 }
 
@@ -386,8 +386,8 @@ export function canonicalAccessControlConditionFormatter(cond) {
 
   throwError({
     description: `You passed an invalid access control condition: ${cond}`,
-    error_kind: "InvalidAccessControlCondition",
-    error_code: "invalid_access_control_condition",
+    error_kind: "Validation",
+    error_code: "NodeIncorrectAccessControlConditions",
   });
 }
 

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -52,19 +52,19 @@ export function canonicalUnifiedAccessControlConditionFormatter(cond) {
       return canonicalCosmosConditionFormatter(cond);
     } else {
       throwError({
-        message: `You passed an invalid access control condition that is missing or has a wrong "conditionType": ${JSON.stringify(
+        description: `You passed an invalid access control condition that is missing or has a wrong "conditionType": ${JSON.stringify(
           cond
         )}`,
-        name: "InvalidAccessControlCondition",
-        errorCode: "invalid_access_control_condition",
+        error_kind: "InvalidAccessControlCondition",
+        error_code: "invalid_access_control_condition",
       });
     }
   }
 
   throwError({
-    message: `You passed an invalid access control condition: ${cond}`,
-    name: "InvalidAccessControlCondition",
-    errorCode: "invalid_access_control_condition",
+    description: `You passed an invalid access control condition: ${cond}`,
+    error_kind: "InvalidAccessControlCondition",
+    error_code: "invalid_access_control_condition",
   });
 }
 
@@ -116,9 +116,9 @@ export function canonicalCosmosConditionFormatter(cond) {
   }
 
   throwError({
-    message: `You passed an invalid access control condition: ${cond}`,
-    name: "InvalidAccessControlCondition",
-    errorCode: "invalid_access_control_condition",
+    description: `You passed an invalid access control condition: ${cond}`,
+    error_kind: "InvalidAccessControlCondition",
+    error_code: "invalid_access_control_condition",
   });
 }
 
@@ -190,9 +190,9 @@ pub struct SolPdaInterface {
         !("pdaKey" in cond)
       ) {
         throwError({
-          message: `Solana RPC Conditions have changed and there are some new fields you must include in your condition.  Check the docs here: https://developer.litprotocol.com/AccessControlConditions/solRpcConditions`,
-          name: "InvalidAccessControlCondition",
-          errorCode: "invalid_access_control_condition",
+          description: `Solana RPC Conditions have changed and there are some new fields you must include in your condition.  Check the docs here: https://developer.litprotocol.com/AccessControlConditions/solRpcConditions`,
+          error_kind: "InvalidAccessControlCondition",
+          error_code: "invalid_access_control_condition",
         });
       }
 
@@ -221,9 +221,9 @@ pub struct SolPdaInterface {
   }
 
   throwError({
-    message: `You passed an invalid access control condition: ${cond}`,
-    name: "InvalidAccessControlCondition",
-    errorCode: "invalid_access_control_condition",
+    description: `You passed an invalid access control condition: ${cond}`,
+    error_kind: "InvalidAccessControlCondition",
+    error_code: "invalid_access_control_condition",
   });
 }
 
@@ -330,9 +330,9 @@ export function canonicalEVMContractConditionFormatter(cond) {
   }
 
   throwError({
-    message: `You passed an invalid access control condition: ${cond}`,
-    name: "InvalidAccessControlCondition",
-    errorCode: "invalid_access_control_condition",
+    description: `You passed an invalid access control condition: ${cond}`,
+    error_kind: "InvalidAccessControlCondition",
+    error_code: "invalid_access_control_condition",
   });
 }
 
@@ -385,9 +385,9 @@ export function canonicalAccessControlConditionFormatter(cond) {
   }
 
   throwError({
-    message: `You passed an invalid access control condition: ${cond}`,
-    name: "InvalidAccessControlCondition",
-    errorCode: "invalid_access_control_condition",
+    description: `You passed an invalid access control condition: ${cond}`,
+    error_kind: "InvalidAccessControlCondition",
+    error_code: "invalid_access_control_condition",
   });
 }
 

--- a/src/utils/eth.js
+++ b/src/utils/eth.js
@@ -189,8 +189,8 @@ export async function checkAndSignEVMAuthMessage({
     log("getNetwork threw an exception", e);
     throwError({
       description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-      error_kind: "WrongNetworkException",
-      error_code: "wrong_network",
+      error_kind: "Validation",
+      error_code: "NodeWrongNetwork",
     });
   }
   let selectedChainId = "0x" + selectedChain.chainId.toString("16");
@@ -204,8 +204,8 @@ export async function checkAndSignEVMAuthMessage({
       // this chain switching won't work.  alert the user that they need to switch chains manually
       throwError({
         description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-        error_kind: "WrongNetworkException",
-        error_code: "wrong_network",
+        error_kind: "Validation",
+        error_code: "NodeWrongNetwork",
       });
       return;
     }
@@ -243,8 +243,8 @@ export async function checkAndSignEVMAuthMessage({
             // metamask code indicating "no such method"
             throwError({
               description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-              error_kind: "WrongNetworkException",
-              error_code: "wrong_network",
+              error_kind: "Validation",
+              error_code: "NodeWrongNetwork",
             });
           } else {
             throw addError;
@@ -255,8 +255,8 @@ export async function checkAndSignEVMAuthMessage({
           // metamask code indicating "no such method"
           throwError({
             description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-            error_kind: "WrongNetworkException",
-            error_code: "wrong_network",
+            error_kind: "Validation",
+            error_code: "NodeWrongNetwork",
           });
         } else {
           throw switchError;

--- a/src/utils/eth.js
+++ b/src/utils/eth.js
@@ -188,9 +188,9 @@ export async function checkAndSignEVMAuthMessage({
     // couldn't get chainId.  throw the incorrect network error
     log("getNetwork threw an exception", e);
     throwError({
-      message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-      name: "WrongNetworkException",
-      errorCode: "wrong_network",
+      description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
+      error_kind: "WrongNetworkException",
+      error_code: "wrong_network",
     });
   }
   let selectedChainId = "0x" + selectedChain.chainId.toString("16");
@@ -203,9 +203,9 @@ export async function checkAndSignEVMAuthMessage({
     if (web3.provider instanceof WalletConnectProvider) {
       // this chain switching won't work.  alert the user that they need to switch chains manually
       throwError({
-        message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-        name: "WrongNetworkException",
-        errorCode: "wrong_network",
+        description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
+        error_kind: "WrongNetworkException",
+        error_code: "wrong_network",
       });
       return;
     }
@@ -242,9 +242,9 @@ export async function checkAndSignEVMAuthMessage({
           if (addError.code === -32601) {
             // metamask code indicating "no such method"
             throwError({
-              message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-              name: "WrongNetworkException",
-              errorCode: "wrong_network",
+              description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
+              error_kind: "WrongNetworkException",
+              error_code: "wrong_network",
             });
           } else {
             throw addError;
@@ -254,9 +254,9 @@ export async function checkAndSignEVMAuthMessage({
         if (switchError.code === -32601) {
           // metamask code indicating "no such method"
           throwError({
-            message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-            name: "WrongNetworkException",
-            errorCode: "wrong_network",
+            description: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
+            error_kind: "WrongNetworkException",
+            error_code: "wrong_network",
           });
         } else {
           throw switchError;
@@ -586,9 +586,9 @@ export async function mintLIT({ chain, quantity }) {
     if (!tokenAddress) {
       log("No token address for this chain.  It's not supported via MintLIT.");
       throwError({
-        message: `This chain is not supported for minting with the Lit token contract because it hasn't been deployed to this chain.  You can use Lit with your own token contract on this chain, though.`,
-        name: "MintingNotSupported",
-        errorCode: "minting_not_supported",
+        description: `This chain is not supported for minting with the Lit token contract because it hasn't been deployed to this chain.  You can use Lit with your own token contract on this chain, though.`,
+        error_kind: "MintingNotSupported",
+        error_code: "minting_not_supported",
       });
       return;
     }

--- a/src/utils/eth.js
+++ b/src/utils/eth.js
@@ -578,7 +578,7 @@ export async function mintLIT({ chain, quantity }) {
       chain,
       switchChain: true,
     });
-    if (authSig.errorCode) {
+    if (authSig.error_code) {
       return authSig;
     }
     const { web3, account } = await connectWeb3();
@@ -587,8 +587,8 @@ export async function mintLIT({ chain, quantity }) {
       log("No token address for this chain.  It's not supported via MintLIT.");
       throwError({
         description: `This chain is not supported for minting with the Lit token contract because it hasn't been deployed to this chain.  You can use Lit with your own token contract on this chain, though.`,
-        error_kind: "MintingNotSupported",
-        error_code: "minting_not_supported",
+        error_kind: "Generic",
+        error_code: "NodeMintingNotSupported",
       });
       return;
     }
@@ -611,11 +611,11 @@ export async function mintLIT({ chain, quantity }) {
     if (error.code === 4001) {
       // EIP-1193 userRejectedRequest error
       log("User rejected request");
-      return { errorCode: "user_rejected_request" };
+      return { error_code: "NodeUserRejectedRequest" };
     } else {
       console.error(error);
     }
-    return { errorCode: "unknown_error" };
+    return { error_code: "NodeUnknownError" };
   }
 }
 
@@ -657,11 +657,11 @@ export async function findLITs() {
     if (error.code === 4001) {
       // EIP-1193 userRejectedRequest error
       log("User rejected request");
-      return { errorCode: "user_rejected_request" };
+      return { error_code: "NodeUserRejectedRequest" };
     } else {
       console.error(error);
     }
-    return { errorCode: "unknown_error" };
+    return { error_code: "NodeUnknownError" };
   }
 }
 
@@ -694,11 +694,11 @@ export async function sendLIT({ tokenMetadata, to }) {
     if (error.code === 4001) {
       // EIP-1193 userRejectedRequest error
       log("User rejected request");
-      return { errorCode: "user_rejected_request" };
+      return { error_code: "NodeUserRejectedRequest" };
     } else {
       console.error(error);
     }
-    return { errorCode: "unknown_error" };
+    return { error_code: "NodeUnknownError" };
   }
 }
 

--- a/src/utils/lit.js
+++ b/src/utils/lit.js
@@ -58,8 +58,8 @@ export async function checkAndSignAuthMessage({
       description: `Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      error_kind: "UnsupportedChainException",
-      error_code: "unsupported_chain",
+      error_kind: "Generic",
+      error_code: "NodeChainNotSupported",
     });
   }
 
@@ -85,8 +85,8 @@ export async function checkAndSignAuthMessage({
       description: `vmType not found for this chain: ${chain}.  This should not happen.  Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      error_kind: "UnsupportedChainException",
-      error_code: "unsupported_chain",
+      error_kind: "Generic",
+      error_code: "NodeChainNotSupported",
     });
   }
 }
@@ -826,7 +826,7 @@ export async function toggleLock() {
     }
 
     const authSig = await checkAndSignAuthMessage({ chain: window.chain });
-    if (authSig.errorCode && authSig.errorCode === "wrong_chain") {
+    if (authSig.error_code && authSig.error_code === "NodeChainNotSupported") {
       alert(
         "You are connected to the wrong blockchain.  Please switch your metamask to " +
           window.chain
@@ -1556,8 +1556,8 @@ export const configure = (config) => {
       throwError({
         description:
           "the litNetwork specified in the LitNodeClient config not found in LIT_NETWORKS",
-        error_kind: "LitNodeClientConfigBad",
-        error_code: "lit_node_client_config_bad",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientConfigBad",
       });
     }
     _config.bootstrapUrls = LIT_NETWORKS[_config.litNetwork];

--- a/src/utils/lit.js
+++ b/src/utils/lit.js
@@ -549,7 +549,7 @@ export async function decryptZipFileWithMetadata({
       authSig,
     });
   } catch (e) {
-    if (e.errorCode === "not_authorized") {
+    if (e.error_code === "NodeNotAuthorized") {
       // try more additionalAccessControlConditions
       if (!additionalAccessControlConditions) {
         throw e;
@@ -575,8 +575,8 @@ export async function decryptZipFileWithMetadata({
 
           break; // it worked, we can leave the loop and stop checking additional access control conditions
         } catch (e) {
-          // swallow not_authorized because we are gonna try some more accessControlConditions
-          if (e.errorCode !== "not_authorized") {
+          // swallow NodeNotAuthorized because we are gonna try some more accessControlConditions
+          if (e.error_code !== "NodeNotAuthorized") {
             throw e;
           }
         }
@@ -1113,8 +1113,8 @@ async function humanizeUnifiedAccessControlConditions({
       } else {
         throwError({
           description: `Unrecognized condition type: ${acc.conditionType}`,
-          error_kind: "InvalidUnifiedConditionType",
-          error_code: "invalid_unified_condition_type",
+          error_kind: "Validation",
+          error_code: "NodeInvalidUnifiedConditionType",
         });
       }
     })

--- a/src/utils/lit.js
+++ b/src/utils/lit.js
@@ -55,11 +55,11 @@ export async function checkAndSignAuthMessage({
   const chainInfo = ALL_LIT_CHAINS[chain];
   if (!chainInfo) {
     throwError({
-      message: `Unsupported chain selected.  Please select one of: ${Object.keys(
+      description: `Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      name: "UnsupportedChainException",
-      errorCode: "unsupported_chain",
+      error_kind: "UnsupportedChainException",
+      error_code: "unsupported_chain",
     });
   }
 
@@ -82,11 +82,11 @@ export async function checkAndSignAuthMessage({
     return checkAndSignCosmosAuthMessage({ chain, resources, expiration, uri });
   } else {
     throwError({
-      message: `vmType not found for this chain: ${chain}.  This should not happen.  Unsupported chain selected.  Please select one of: ${Object.keys(
+      description: `vmType not found for this chain: ${chain}.  This should not happen.  Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      name: "UnsupportedChainException",
-      errorCode: "unsupported_chain",
+      error_kind: "UnsupportedChainException",
+      error_code: "unsupported_chain",
     });
   }
 }
@@ -1112,9 +1112,9 @@ async function humanizeUnifiedAccessControlConditions({
         });
       } else {
         throwError({
-          message: `Unrecognized condition type: ${acc.conditionType}`,
-          name: "InvalidUnifiedConditionType",
-          errorCode: "invalid_unified_condition_type",
+          description: `Unrecognized condition type: ${acc.conditionType}`,
+          error_kind: "InvalidUnifiedConditionType",
+          error_code: "invalid_unified_condition_type",
         });
       }
     })
@@ -1554,10 +1554,10 @@ export const configure = (config) => {
     if (!(_config.litNetwork in LIT_NETWORKS)) {
       // network not found, report error
       throwError({
-        message:
+        description:
           "the litNetwork specified in the LitNodeClient config not found in LIT_NETWORKS",
-        name: "LitNodeClientConfigBad",
-        errorCode: "lit_node_client_config_bad",
+        error_kind: "LitNodeClientConfigBad",
+        error_code: "lit_node_client_config_bad",
       });
     }
     _config.bootstrapUrls = LIT_NETWORKS[_config.litNetwork];

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -1995,9 +1995,9 @@ export default class LitNodeClient {
   }
 
   throwNodeError(res) {
-    if (res.error && res.error.errorCode) {
+    if (res.error && res.error.error_code) {
       if (
-        res.error.errorCode === "not_authorized" &&
+        res.error.error_code === "not_authorized" &&
         this.config.alertWhenUnauthorized
       ) {
         alert("You are not authorized to access to this content");
@@ -2007,7 +2007,7 @@ export default class LitNodeClient {
       throwError({
         message: `There was an error getting the signing shares from the nodes`,
         name: "UnknownError",
-        errorCode: "unknown_error",
+        error_code: "unknown_error",
       });
     }
   }

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -140,27 +140,28 @@ export default class LitNodeClient {
   }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
     const chainId = LIT_CHAINS[chain].chainId;
     if (!chainId) {
       throwError({
-        message: "Invalid chain.  Please pass a valid chain.",
-        name: "InvalidChain",
-        errorCode: "invalid_input_chain",
+        description: "Invalid chain.  Please pass a valid chain.",
+        error_kind: "InvalidChain",
+        error_code: "invalid_input_chain",
       });
     }
 
     if (!publicKey) {
       throwError({
-        message: "Pubic Key not provided.  Please pass a valid Public Key.",
-        name: "MissingPublicKey",
-        errorCode: "missing_public_key",
+        description: "Pubic Key not provided.  Please pass a valid Public Key.",
+        error_kind: "MissingPublicKey",
+        error_code: "missing_public_key",
       });
     }
 
@@ -267,10 +268,11 @@ export default class LitNodeClient {
   }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -299,9 +301,9 @@ export default class LitNodeClient {
 
     if (!sessionSigs && !authSig) {
       throwError({
-        message: "You must pass either authSig or sessionSigs",
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: "You must pass either authSig or sessionSigs",
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
       return;
     }
@@ -324,9 +326,9 @@ export default class LitNodeClient {
       reqBody.ipfsId = ipfsId;
     } else {
       throwError({
-        message: "You must pass either code or ipfsId",
-        name: "MissingParameterError",
-        errorCode: "missing_parameter",
+        description: "You must pass either code or ipfsId",
+        error_kind: "MissingParameterError",
+        error_code: "missing_parameter",
       });
     }
 
@@ -341,9 +343,10 @@ export default class LitNodeClient {
         sigToPassToNode = sessionSigs[url];
         if (!sigToPassToNode) {
           throwError({
-            message: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            name: "InvalidArgumentException",
-            errorCode: "invalid_argument",
+            description: `You passed sessionSigs but we could not find session sig for node ${url}`,
+            error_kind: "InvalidArgumentException",
+            error_code: "invalid_argument",
+            status: 401,
           });
         }
       }
@@ -389,9 +392,9 @@ export default class LitNodeClient {
         signature = combineEcdsaShares(sigShares);
       } else {
         throwError({
-          message: "Unknown signature type",
-          name: "UnknownSignatureTypeError",
-          errorCode: "unknown_signature_type",
+          description: "Unknown signature type",
+          error_kind: "UnknownSignatureTypeError",
+          error_code: "unknown_signature_type",
         });
       }
 
@@ -435,9 +438,9 @@ export default class LitNodeClient {
         );
       } else {
         throwError({
-          message: "Unknown decryption algorithm type",
-          name: "UnknownDecryptionAlgorithmTypeError",
-          errorCode: "unknown_decryption_algorithm_type",
+          description: "Unknown decryption algorithm type",
+          error_kind: "UnknownDecryptionAlgorithmTypeError",
+          error_code: "unknown_decryption_algorithm_type",
         });
       }
 
@@ -501,10 +504,11 @@ export default class LitNodeClient {
   }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -589,9 +593,9 @@ export default class LitNodeClient {
         signature = combineEcdsaShares(sigShares);
       } else {
         throwError({
-          message: "Unknown signature type",
-          name: "UnknownSignatureTypeError",
-          errorCode: "unknown_signature_type",
+          description: "Unknown signature type",
+          error_kind: "UnknownSignatureTypeError",
+          error_code: "unknown_signature_type",
         });
       }
 
@@ -630,10 +634,11 @@ export default class LitNodeClient {
   async getSignedChainDataToken({ callRequests, chain }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -673,9 +678,10 @@ export default class LitNodeClient {
       }
 
       throwError({
-        message: `You are not authorized to recieve a signature on this item`,
-        name: "UnauthorizedException",
-        errorCode: "not_authorized",
+        description: `You are not authorized to recieve a signature on this item`,
+        error_kind: "UnauthorizedException",
+        error_code: "not_authorized",
+        status: 401,
       });
     }
 
@@ -747,10 +753,11 @@ export default class LitNodeClient {
   }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -830,9 +837,9 @@ export default class LitNodeClient {
 
     if (!sessionSigs && !authSig) {
       throwError({
-        message: "You must pass either authSig or sessionSigs",
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: "You must pass either authSig or sessionSigs",
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
       return;
     }
@@ -889,9 +896,9 @@ export default class LitNodeClient {
       );
     } else {
       throwError({
-        message: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
     }
 
@@ -906,9 +913,9 @@ export default class LitNodeClient {
         sigToPassToNode = sessionSigs[url];
         if (!sigToPassToNode) {
           throwError({
-            message: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            name: "InvalidArgumentException",
-            errorCode: "invalid_argument",
+            description: `You passed sessionSigs but we could not find session sig for node ${url}`,
+            error_kind: "InvalidArgumentException",
+            error_code: "invalid_argument",
           });
         }
       }
@@ -1010,10 +1017,11 @@ export default class LitNodeClient {
 
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -1093,9 +1101,9 @@ export default class LitNodeClient {
 
     if (!sessionSigs && !authSig) {
       throwError({
-        message: "You must pass either authSig or sessionSigs",
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: "You must pass either authSig or sessionSigs",
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
       return;
     }
@@ -1134,9 +1142,9 @@ export default class LitNodeClient {
       );
     } else {
       throwError({
-        message: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
     }
 
@@ -1197,10 +1205,11 @@ export default class LitNodeClient {
   }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -1277,9 +1286,9 @@ export default class LitNodeClient {
 
     if (!sessionSigs && !authSig) {
       throwError({
-        message: "You must pass either authSig or sessionSigs",
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: "You must pass either authSig or sessionSigs",
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
       return;
     }
@@ -1329,9 +1338,9 @@ export default class LitNodeClient {
       );
     } else {
       throwError({
-        message: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
     }
 
@@ -1344,9 +1353,10 @@ export default class LitNodeClient {
         sigToPassToNode = sessionSigs[url];
         if (!sigToPassToNode) {
           throwError({
-            message: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            name: "InvalidArgumentException",
-            errorCode: "invalid_argument",
+            description: `You passed sessionSigs but we could not find session sig for node ${url}`,
+            error_kind: "InvalidArgumentException",
+            error_code: "invalid_argument",
+            status: 401,
           });
         }
       }
@@ -1444,10 +1454,11 @@ export default class LitNodeClient {
 
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -1516,9 +1527,9 @@ export default class LitNodeClient {
       return;
     if (!sessionSigs && !authSig) {
       throwError({
-        message: "You must pass either authSig or sessionSigs",
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: "You must pass either authSig or sessionSigs",
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
       return;
     }
@@ -1612,9 +1623,9 @@ export default class LitNodeClient {
       );
     } else {
       throwError({
-        message: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
     }
 
@@ -1632,9 +1643,10 @@ export default class LitNodeClient {
         sigToPassToNode = sessionSigs[url];
         if (!sigToPassToNode) {
           throwError({
-            message: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            name: "InvalidArgumentException",
-            errorCode: "invalid_argument",
+            description: `You passed sessionSigs but we could not find session sig for node ${url}`,
+            error_kind: "InvalidArgumentException",
+            error_code: "invalid_argument",
+            status: 401,
           });
         }
       }
@@ -1713,10 +1725,11 @@ export default class LitNodeClient {
   async validate_and_sign_ecdsa({ accessControlConditions, chain, auth_sig }) {
     if (!this.ready) {
       throwError({
-        message:
+        description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        name: "LitNodeClientNotReadyError",
-        errorCode: "lit_node_client_not_ready",
+        error_kind: "LitNodeClientNotReadyError",
+        error_code: "lit_node_client_not_ready",
+        status: 403,
       });
     }
 
@@ -1758,9 +1771,9 @@ export default class LitNodeClient {
     // }
     else {
       throwError({
-        message: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions`,
-        name: "InvalidArgumentException",
-        errorCode: "invalid_argument",
+        description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions`,
+        error_kind: "InvalidArgumentException",
+        error_code: "invalid_argument",
       });
     }
 
@@ -2005,9 +2018,10 @@ export default class LitNodeClient {
       throwError({ ...res.error, name: "NodeError" });
     } else {
       throwError({
-        message: `There was an error getting the signing shares from the nodes`,
-        name: "UnknownError",
+        description: `There was an error getting the signing shares from the nodes`,
+        error_kind: "UnknownError",
         error_code: "unknown_error",
+        status: 500,
       });
     }
   }

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -152,16 +152,16 @@ export default class LitNodeClient {
     if (!chainId) {
       throwError({
         description: "Invalid chain.  Please pass a valid chain.",
-        error_kind: "InvalidChain",
-        error_code: "invalid_input_chain",
+        error_kind: "Generic",
+        error_code: "NodeChainNotSupported",
       });
     }
 
     if (!publicKey) {
       throwError({
         description: "Pubic Key not provided.  Please pass a valid Public Key.",
-        error_kind: "MissingPublicKey",
-        error_code: "missing_public_key",
+        error_kind: "Generic",
+        error_code: "NodeMissingPublicKey",
       });
     }
 
@@ -327,8 +327,8 @@ export default class LitNodeClient {
     } else {
       throwError({
         description: "You must pass either code or ipfsId",
-        error_kind: "MissingParameterError",
-        error_code: "missing_parameter",
+        error_kind: "Generic",
+        error_code: "NodeMissingParameter",
       });
     }
 
@@ -393,8 +393,8 @@ export default class LitNodeClient {
       } else {
         throwError({
           description: "Unknown signature type",
-          error_kind: "UnknownSignatureTypeError",
-          error_code: "unknown_signature_type",
+          error_kind: "Generic",
+          error_code: "UnknownSignatureType",
         });
       }
 
@@ -439,8 +439,8 @@ export default class LitNodeClient {
       } else {
         throwError({
           description: "Unknown decryption algorithm type",
-          error_kind: "UnknownDecryptionAlgorithmTypeError",
-          error_code: "unknown_decryption_algorithm_type",
+          error_kind: "Generic",
+          error_code: "UnknownDecryptionAlgorithmTypeError",
         });
       }
 
@@ -594,8 +594,8 @@ export default class LitNodeClient {
       } else {
         throwError({
           description: "Unknown signature type",
-          error_kind: "UnknownSignatureTypeError",
-          error_code: "unknown_signature_type",
+          error_kind: "Generic",
+          error_code: "UnknownSignatureType",
         });
       }
 
@@ -2015,7 +2015,7 @@ export default class LitNodeClient {
       ) {
         alert("You are not authorized to access to this content");
       }
-      throwError({ ...res.error, name: "NodeError" });
+      throwError({ ...res.error });
     } else {
       throwError({
         description: `There was an error getting the signing shares from the nodes`,

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -144,7 +144,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -272,7 +272,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -302,7 +302,7 @@ export default class LitNodeClient {
     if (!sessionSigs && !authSig) {
       throwError({
         description: "You must pass either authSig or sessionSigs",
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
       return;
@@ -328,7 +328,7 @@ export default class LitNodeClient {
       throwError({
         description: "You must pass either code or ipfsId",
         error_kind: "Generic",
-        error_code: "NodeMissingParameter",
+        error_code: "NodeInvalidArgument",
       });
     }
 
@@ -344,7 +344,7 @@ export default class LitNodeClient {
         if (!sigToPassToNode) {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            error_kind: "InvalidArgumentException",
+            error_kind: "Generic",
             error_code: "NodeInvalidArgument",
             status: 401,
           });
@@ -508,7 +508,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -638,7 +638,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -757,7 +757,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -838,7 +838,7 @@ export default class LitNodeClient {
     if (!sessionSigs && !authSig) {
       throwError({
         description: "You must pass either authSig or sessionSigs",
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
       return;
@@ -897,7 +897,7 @@ export default class LitNodeClient {
     } else {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
     }
@@ -914,7 +914,7 @@ export default class LitNodeClient {
         if (!sigToPassToNode) {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            error_kind: "InvalidArgumentException",
+            error_kind: "Generic",
             error_code: "NodeInvalidArgument",
           });
         }
@@ -1021,7 +1021,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -1102,7 +1102,7 @@ export default class LitNodeClient {
     if (!sessionSigs && !authSig) {
       throwError({
         description: "You must pass either authSig or sessionSigs",
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
       return;
@@ -1143,7 +1143,7 @@ export default class LitNodeClient {
     } else {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
     }
@@ -1209,7 +1209,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -1287,7 +1287,7 @@ export default class LitNodeClient {
     if (!sessionSigs && !authSig) {
       throwError({
         description: "You must pass either authSig or sessionSigs",
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
       return;
@@ -1339,7 +1339,7 @@ export default class LitNodeClient {
     } else {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
     }
@@ -1354,9 +1354,8 @@ export default class LitNodeClient {
         if (!sigToPassToNode) {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            error_kind: "InvalidArgumentException",
+            error_kind: "Generic",
             error_code: "NodeInvalidArgument",
-            status: 401,
           });
         }
       }
@@ -1458,7 +1457,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -1528,7 +1527,7 @@ export default class LitNodeClient {
     if (!sessionSigs && !authSig) {
       throwError({
         description: "You must pass either authSig or sessionSigs",
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
       return;
@@ -1624,7 +1623,7 @@ export default class LitNodeClient {
     } else {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
     }
@@ -1644,9 +1643,8 @@ export default class LitNodeClient {
         if (!sigToPassToNode) {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
-            error_kind: "InvalidArgumentException",
+            error_kind: "Generic",
             error_code: "NodeInvalidArgument",
-            status: 401,
           });
         }
       }
@@ -1729,7 +1727,7 @@ export default class LitNodeClient {
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
         error_kind: "Config",
         error_code: "NodeLitNodeClientNotReady",
-        status: 403,
+        status: 401,
       });
     }
 
@@ -1772,7 +1770,7 @@ export default class LitNodeClient {
     else {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions`,
-        error_kind: "InvalidArgumentException",
+        error_kind: "Generic",
         error_code: "NodeInvalidArgument",
       });
     }
@@ -2021,7 +2019,6 @@ export default class LitNodeClient {
         description: `There was an error getting the signing shares from the nodes`,
         error_kind: "UnknownError",
         error_code: "NodeUnknownError",
-        status: 400,
       });
     }
   }

--- a/src/utils/litNodeClient.js
+++ b/src/utils/litNodeClient.js
@@ -142,8 +142,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -270,8 +270,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -303,7 +303,7 @@ export default class LitNodeClient {
       throwError({
         description: "You must pass either authSig or sessionSigs",
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
       return;
     }
@@ -345,7 +345,7 @@ export default class LitNodeClient {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
             error_kind: "InvalidArgumentException",
-            error_code: "invalid_argument",
+            error_code: "NodeInvalidArgument",
             status: 401,
           });
         }
@@ -506,8 +506,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -636,8 +636,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -679,9 +679,9 @@ export default class LitNodeClient {
 
       throwError({
         description: `You are not authorized to recieve a signature on this item`,
-        error_kind: "UnauthorizedException",
-        error_code: "not_authorized",
-        status: 401,
+        error_kind: "Validation",
+        error_code: "NodeNotAuthorized",
+        status: 403,
       });
     }
 
@@ -755,8 +755,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -839,7 +839,7 @@ export default class LitNodeClient {
       throwError({
         description: "You must pass either authSig or sessionSigs",
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
       return;
     }
@@ -898,7 +898,7 @@ export default class LitNodeClient {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
     }
 
@@ -915,7 +915,7 @@ export default class LitNodeClient {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
             error_kind: "InvalidArgumentException",
-            error_code: "invalid_argument",
+            error_code: "NodeInvalidArgument",
           });
         }
       }
@@ -1019,8 +1019,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -1103,7 +1103,7 @@ export default class LitNodeClient {
       throwError({
         description: "You must pass either authSig or sessionSigs",
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
       return;
     }
@@ -1144,7 +1144,7 @@ export default class LitNodeClient {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
     }
 
@@ -1207,8 +1207,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -1288,7 +1288,7 @@ export default class LitNodeClient {
       throwError({
         description: "You must pass either authSig or sessionSigs",
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
       return;
     }
@@ -1340,7 +1340,7 @@ export default class LitNodeClient {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
     }
 
@@ -1355,7 +1355,7 @@ export default class LitNodeClient {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
             error_kind: "InvalidArgumentException",
-            error_code: "invalid_argument",
+            error_code: "NodeInvalidArgument",
             status: 401,
           });
         }
@@ -1456,8 +1456,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -1529,7 +1529,7 @@ export default class LitNodeClient {
       throwError({
         description: "You must pass either authSig or sessionSigs",
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
       return;
     }
@@ -1625,7 +1625,7 @@ export default class LitNodeClient {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions or unifiedAccessControlConditions`,
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
     }
 
@@ -1645,7 +1645,7 @@ export default class LitNodeClient {
           throwError({
             description: `You passed sessionSigs but we could not find session sig for node ${url}`,
             error_kind: "InvalidArgumentException",
-            error_code: "invalid_argument",
+            error_code: "NodeInvalidArgument",
             status: 401,
           });
         }
@@ -1727,8 +1727,8 @@ export default class LitNodeClient {
       throwError({
         description:
           "LitNodeClient is not ready.  Please call await litNodeClient.connect() first.",
-        error_kind: "LitNodeClientNotReadyError",
-        error_code: "lit_node_client_not_ready",
+        error_kind: "Config",
+        error_code: "NodeLitNodeClientNotReady",
         status: 403,
       });
     }
@@ -1773,7 +1773,7 @@ export default class LitNodeClient {
       throwError({
         description: `You must provide either accessControlConditions or evmContractConditions or solRpcConditions`,
         error_kind: "InvalidArgumentException",
-        error_code: "invalid_argument",
+        error_code: "NodeInvalidArgument",
       });
     }
 
@@ -2010,7 +2010,7 @@ export default class LitNodeClient {
   throwNodeError(res) {
     if (res.error && res.error.error_code) {
       if (
-        res.error.error_code === "not_authorized" &&
+        res.error.error_code === "NodeNotAuthorized" &&
         this.config.alertWhenUnauthorized
       ) {
         alert("You are not authorized to access to this content");
@@ -2020,8 +2020,8 @@ export default class LitNodeClient {
       throwError({
         description: `There was an error getting the signing shares from the nodes`,
         error_kind: "UnknownError",
-        error_code: "unknown_error",
-        status: 500,
+        error_code: "NodeUnknownError",
+        status: 400,
       });
     }
   }

--- a/src/utils/sol.js
+++ b/src/utils/sol.js
@@ -15,10 +15,10 @@ function getProvider() {
     // }
   } else {
     throwError({
-      message:
+      description:
         "No web3 wallet was found that works with Solana.  Install a Solana wallet or choose another chain",
-      name: "NoWalletException",
-      errorCode: "no_wallet",
+      error_kind: "NoWalletException",
+      error_code: "no_wallet",
     });
   }
 }

--- a/src/utils/sol.js
+++ b/src/utils/sol.js
@@ -17,8 +17,8 @@ function getProvider() {
     throwError({
       description:
         "No web3 wallet was found that works with Solana.  Install a Solana wallet or choose another chain",
-      error_kind: "NoWalletException",
-      error_code: "no_wallet",
+      error_kind: "Generic",
+      error_code: "NodeNoWallet",
     });
   }
 }


### PR DESCRIPTION
# What

- Throw the errors returned by node (lit-core-rs error format). These are the new errors objects returned by the nodes.
- Some error checking is also done on the client side, standardize those errors to be of the same format as the node errors.

# How

- Update the `throwError()` params to match the node errors

**Note:** Have updated the key `message` to `description` in the thrown error to match node error keys.

# Tests

To test that the new node errors are being thrown just match the console logged node errors (node errors are logged on the console as most common error, you may also check individual errors in the returned object) with the ones "thrown".