### PR TITLE
Feat: Update modal to include Coinbase Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cross-blob": "^3.0.1",
     "js-base64": "^3.7.2",
     "jszip": "^3.6.0",
-    "lit-connect-modal": "^0.1.10",
+    "lit-connect-modal": "^0.1.11",
     "lit-siwe": "^1.1.8",
     "node-fetch": "^3.2.3",
     "pako": "^2.0.4",

--- a/packages/sdk-browser-standalone/package.json
+++ b/packages/sdk-browser-standalone/package.json
@@ -18,7 +18,7 @@
     "cross-blob": "^3.0.1",
     "js-base64": "^3.7.2",
     "jszip": "^3.6.0",
-    "lit-connect-modal": "^0.1.10",
+    "lit-connect-modal": "^0.1.11",
     "lit-siwe": "^1.1.8",
     "node-fetch": "^3.2.3",
     "pako": "^2.0.4",

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -18,7 +18,7 @@
     "cross-blob": "^3.0.1",
     "js-base64": "^3.7.2",
     "jszip": "^3.6.0",
-    "lit-connect-modal": "^0.1.10",
+    "lit-connect-modal": "^0.1.11",
     "lit-siwe": "^1.1.8",
     "node-fetch": "^3.2.3",
     "pako": "^2.0.4",

--- a/packages/sdk-nodejs/package.json
+++ b/packages/sdk-nodejs/package.json
@@ -18,7 +18,7 @@
     "cross-blob": "^3.0.1",
     "js-base64": "^3.7.2",
     "jszip": "^3.6.0",
-    "lit-connect-modal": "^0.1.10",
+    "lit-connect-modal": "^0.1.11",
     "lit-siwe": "^1.1.8",
     "node-fetch": "^3.2.3",
     "pako": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3540,10 +3540,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lit-connect-modal@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/lit-connect-modal/-/lit-connect-modal-0.1.10.tgz#b9f6008aaa10a19e9accd2bf447853429fbe270c"
-  integrity sha512-hiE/0yrl15EDNH08OqcntiNXDOvU4zviiaOOCT4jG2N3L2dyMFLOwXXrkNobQ6B8/8MgXmMJu2TCp6RwhmCzNw==
+lit-connect-modal@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/lit-connect-modal/-/lit-connect-modal-0.1.11.tgz#688fa9601b920c917856a5dbe8491a4fbaf1d6ab"
+  integrity sha512-EG6pcCqdxZQJt3MPDq3gJ5Sz4E5sJdydtAF7VFJu6z6GDHO1Ybp8WrTx8CUnHiF54/MQBRi6Nb7cbTvv+BKWvQ==
   dependencies:
     micromodal "^0.4.10"
 


### PR DESCRIPTION
# What

Updated the lit-connect-modal versions in all 4 package.json to include Coinbase Wallet in the modal.

# Why

A team requested this feature.

# How

Simple package & yarn.lock update

# Additional Info:

A similar PR for the main branch which will be publish to `lit-js-sdk`

# Next Steps

Publish the latest version to the `lit-js-sdk@serrano` on the npm registry

# Tests

May test this functionality using the manual_test.html file, specifically the Coinbase Wallet.
I have tested using the above approach with all the below Chrome configurations:
- [X] No Metamask- Only option WalletConnect
- [X] Only Metamask, no Coinbase Wallet- Metamask & WalletConnect
- [X] Metamask & Other wallets except Coinbase- Metamask & WalletConnect
- [X] Metamask & Coinbase Wallet- Shows all 3, Metamask, Coinbase Wallet & WalletConnect